### PR TITLE
Make quiz page default route and enhance prominence

### DIFF
--- a/client/App.tsx
+++ b/client/App.tsx
@@ -5,7 +5,7 @@ import { createRoot } from "react-dom/client";
 import { Toaster as Sonner } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
 import Index from "./pages/Index";
 import Compare from "./pages/Compare";
 import CompareIntro from "./pages/CompareIntro";
@@ -23,7 +23,8 @@ const App = () => (
       <Sonner />
       <BrowserRouter>
         <Routes>
-          <Route path="/" element={<Index />} />
+          <Route path="/" element={<Navigate to="/quiz-intro" replace />} />
+          <Route path="/fragrances" element={<Index />} />
           <Route path="/compare-intro" element={<CompareIntro />} />
           <Route path="/compare" element={<Compare />} />
           <Route path="/quiz-intro" element={<QuizIntro />} />

--- a/client/components/Header.tsx
+++ b/client/components/Header.tsx
@@ -9,7 +9,7 @@ export function Header() {
   const location = useLocation();
 
   const navigation = [
-    { name: "Fragrances", href: "/", icon: Crown },
+    { name: "Fragrances", href: "/fragrances", icon: Crown },
     { name: "Compare", href: "/compare", icon: Scale },
     { name: "Quiz", href: "/quiz-intro", icon: Heart },
     { name: "Mixer", href: "/mixer", icon: Beaker },

--- a/client/components/Header.tsx
+++ b/client/components/Header.tsx
@@ -9,9 +9,9 @@ export function Header() {
   const location = useLocation();
 
   const navigation = [
+    { name: "Quiz", href: "/quiz-intro", icon: Heart },
     { name: "Fragrances", href: "/fragrances", icon: Crown },
     { name: "Compare", href: "/compare", icon: Scale },
-    { name: "Quiz", href: "/quiz-intro", icon: Heart },
     { name: "Mixer", href: "/mixer", icon: Beaker },
   ];
 
@@ -43,18 +43,21 @@ export function Header() {
               const Icon = item.icon;
               const isActive = item.href === location.pathname;
 
+              const base = "flex items-center gap-2 px-3 py-2 rounded-lg font-semibold transition-all duration-200";
+              const emphasized = item.name === "Quiz";
+              const classes = emphasized
+                ? `${base} bg-gold-500 text-black-950 shadow-md`
+                : isActive
+                ? `${base} bg-gold-500 text-black-950 shadow-md`
+                : `${base} text-gold-300 hover:bg-gold-600 hover:text-black-950`;
+
               return (
-                <Link
-                  key={item.name}
-                  to={item.href}
-                  className={`flex items-center gap-2 px-3 py-2 rounded-lg font-semibold transition-all duration-200 ${
-                    isActive
-                      ? "bg-gold-500 text-black-950 shadow-md"
-                      : "text-gold-300 hover:bg-gold-600 hover:text-black-950"
-                  }`}
-                >
+                <Link key={item.name} to={item.href} className={classes}>
                   <Icon className="w-6 h-6" />
                   {item.name}
+                  {item.name === "Quiz" && (
+                    <Badge className="ml-1 bg-gold-600 text-black-950">Start here</Badge>
+                  )}
                 </Link>
               );
             })}
@@ -84,6 +87,7 @@ export function Header() {
               {navigation.map((item) => {
                 const Icon = item.icon;
                 const isActive = item.href === location.pathname;
+                const emphasized = item.name === "Quiz";
 
                 return (
                   <Link
@@ -91,13 +95,18 @@ export function Header() {
                     to={item.href}
                     onClick={() => setIsMobileMenuOpen(false)}
                     className={`flex items-center gap-3 px-3 py-2 rounded-lg font-semibold transition-colors ${
-                      isActive
+                      emphasized
+                        ? "bg-gold-500 text-black-950"
+                        : isActive
                         ? "bg-gold-500 text-black-950"
                         : "text-gold-300 hover:bg-gold-600 hover:text-black-950"
                     }`}
                   >
                     <Icon className="w-6 h-6" />
                     {item.name}
+                    {emphasized && (
+                      <Badge className="ml-1 bg-gold-600 text-black-950">Start here</Badge>
+                    )}
                   </Link>
                 );
               })}

--- a/client/pages/Quiz.tsx
+++ b/client/pages/Quiz.tsx
@@ -498,7 +498,7 @@ export default function Quiz() {
             {!showResults ? (
               <div className="space-y-6">
                 <div>
-                  <h3 className="text-lg sm:text-xl font-semibold text-gold-300 mb-6 text-center">
+                  <h3 className="text-lg sm:text-xl font-semibold text-gold-300 mb-6 text-center break-words whitespace-normal hyphens-auto px-2">
                     {quizQuestions[currentQuestion].question}
                   </h3>
 
@@ -510,18 +510,18 @@ export default function Quiz() {
                           key={option.id}
                           type="button"
                           onClick={() => handleAnswer(option)}
-                          className="group relative block w-full rounded-2xl border border-gold-400/60 bg-black-900/70 hover:bg-black-800 transition-all duration-200 hover:shadow-[0_0_0_2px_rgba(253,216,53,0.4)] focus:outline-none focus:ring-2 focus:ring-gold-500/40"
-                          style={{ height: "clamp(9rem, 18vw, 12rem)" }}
+                          className="group relative block w-full rounded-2xl border border-gold-400/60 bg-black-900/70 hover:bg-black-800 transition-all duration-200 hover:shadow-[0_0_0_2px_rgba(253,216,53,0.4)] focus:outline-none focus:ring-2 focus:ring-gold-500/40 overflow-hidden"
+                          style={{ minHeight: "9rem" }}
                         >
                           <div className="flex flex-col h-full">
                             <div className="flex items-center justify-center p-3 sm:p-4 flex-1">
                               <IconComponent strokeWidth={2} className="text-gold-500 w-12 h-12 sm:w-14 sm:h-14 md:w-16 md:h-16" />
                             </div>
                             <div className="flex flex-col items-center justify-center text-center px-3 sm:px-4 py-2 gap-1">
-                              <div className="font-semibold text-xs sm:text-sm leading-tight break-words">
+                              <div className="font-semibold text-xs sm:text-sm leading-tight break-words whitespace-normal hyphens-auto">
                                 {option.text}
                               </div>
-                              <div className="text-[10px] sm:text-xs text-gold-300 leading-relaxed break-words px-1">
+                              <div className="text-[10px] sm:text-xs text-gold-300 leading-relaxed break-words whitespace-normal hyphens-auto px-1">
                                 {option.traits.slice(0, 3).join(", ")}
                               </div>
                             </div>

--- a/client/pages/Quiz.tsx
+++ b/client/pages/Quiz.tsx
@@ -412,7 +412,7 @@ export default function Quiz() {
   const progress = ((currentQuestion + 1) / quizQuestions.length) * 100;
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-black-800 via-black-800 to-black-800 flex flex-col">
+    <div className="min-h-screen bg-gradient-to-br from-black-800 via-black-800 to-black-800 flex flex-col overflow-hidden">
       <Header />
 
       {/* Page Header */}
@@ -437,7 +437,7 @@ export default function Quiz() {
         </div>
       </div>
 
-      <div className="flex-1 max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-4 sm:py-6">
+      <div className="flex-1 max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-4 sm:py-6">
         <Card
           className="bg-gradient-to-br from-black-800 via-black-800 to-black-700 border-2 border-gold-400 shadow-xl relative flex flex-col min-h-[calc(100vh-16rem)]
         before:absolute before:inset-0 before:bg-gradient-to-r before:from-transparent before:via-white/5 before:to-transparent before:translate-x-[-200%] before:animate-shimmer before:transition-transform"
@@ -502,7 +502,7 @@ export default function Quiz() {
                     {quizQuestions[currentQuestion].question}
                   </h3>
 
-                  <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-3 sm:gap-4 md:gap-5 lg:gap-4 max-w-7xl mx-auto">
+                  <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-3 sm:gap-4 md:gap-5 lg:gap-4 max-w-full mx-auto">
                     {quizQuestions[currentQuestion].options.map((option) => {
                       const IconComponent = option.icon;
                       return (
@@ -623,7 +623,7 @@ export default function Quiz() {
                     Take Quiz Again
                   </Button>
                   <Button
-                    onClick={() => navigate("/")}
+                    onClick={() => navigate("/fragrances")}
                     className="flex-1 bg-gold-600 hover:bg-gold-700 text-white font-semibold py-2 sm:py-3 text-sm sm:text-base"
                   >
                     <span className="hidden sm:inline">

--- a/client/pages/QuizIntro.tsx
+++ b/client/pages/QuizIntro.tsx
@@ -28,7 +28,7 @@ export default function QuizIntro() {
               <Heart className="w-7 h-7 text-gold-700" />
               <Sparkles className="w-3 h-3 text-gold-500 absolute -top-1 -right-1" />
             </div>
-            <h1 className="text-2xl font-bold text-gold-300">Fragrance Quiz</h1>
+            <h1 className="text-3xl sm:text-4xl font-bold text-gold-300">Fragrance Quiz</h1>
           </div>
           <p className="text-sm text-gold-300 mb-3">
             Find your perfect scent in under 3 minutes
@@ -117,12 +117,13 @@ export default function QuizIntro() {
         <div className="space-y-3">
           <Button
             onClick={() => navigate("/quiz")}
-            className="w-full bg-gold-600 hover:bg-gold-700 text-black-800 font-semibold py-4 text-base"
+            className="w-full bg-gold-600 hover:bg-gold-700 text-black-900 font-semibold py-5 text-lg shadow-lg ring-2 ring-gold-400"
           >
             <Heart className="w-4 h-4 mr-2" />
             Start Your Fragrance Journey
             <ArrowRight className="w-4 h-4 ml-2" />
           </Button>
+          <p className="text-xs text-gold-400 text-center">Most users start here</p>
 
           <Button
             variant="outline"

--- a/client/pages/QuizIntro.tsx
+++ b/client/pages/QuizIntro.tsx
@@ -17,8 +17,10 @@ export default function QuizIntro() {
   const navigate = useNavigate();
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-black-800 via-black-800 to-black-800">
+    <div className="relative min-h-screen bg-gradient-to-br from-black-900 via-black-900 to-black-800 overflow-hidden">
       <Header />
+
+      <div aria-hidden className="pointer-events-none absolute inset-0 opacity-40 bg-[radial-gradient(1200px_600px_at_50%_-100px,rgba(253,216,53,0.15),transparent)]" />
 
       <div className="max-w-lg mx-auto px-4 py-6">
         {/* Enhanced Header */}
@@ -28,7 +30,7 @@ export default function QuizIntro() {
               <Heart className="w-7 h-7 text-gold-700" />
               <Sparkles className="w-3 h-3 text-gold-500 absolute -top-1 -right-1" />
             </div>
-            <h1 className="text-3xl sm:text-4xl font-bold text-gold-300">Fragrance Quiz</h1>
+            <h1 className="text-3xl sm:text-4xl font-bold tracking-tight text-gold-300">Fragrance Quiz</h1>
           </div>
           <p className="text-sm text-gold-300 mb-3">
             Find your perfect scent in under 3 minutes
@@ -39,8 +41,10 @@ export default function QuizIntro() {
           </p>
         </div>
 
+        <div className="h-px bg-gradient-to-r from-transparent via-gold-500/20 to-transparent my-6" />
+
         {/* What You'll Get */}
-        <Card className="bg-black-800 border border-black-700 shadow-sm mb-4">
+        <Card className="bg-gradient-to-b from-black-900 to-black-800 border border-gold-500/10 rounded-2xl shadow-lg mb-5">
           <CardContent className="p-4">
             <h3 className="text-sm font-semibold text-gold-300 mb-3 flex items-center gap-2">
               <Target className="w-4 h-4 text-gold-600" />
@@ -85,7 +89,7 @@ export default function QuizIntro() {
         </Card>
 
         {/* Quick Facts */}
-        <Card className="bg-black-800 border border-black-700 shadow-sm mb-6">
+        <Card className="bg-gradient-to-b from-black-900 to-black-800 border border-gold-500/10 rounded-2xl shadow-lg mb-8">
           <CardContent className="p-4">
             <div className="grid grid-cols-3 gap-3 text-center">
               <div className="space-y-1">
@@ -117,7 +121,7 @@ export default function QuizIntro() {
         <div className="space-y-3">
           <Button
             onClick={() => navigate("/quiz")}
-            className="w-full bg-gold-600 hover:bg-gold-700 text-black-900 font-semibold py-5 text-lg shadow-lg ring-2 ring-gold-400"
+            className="w-full bg-gold-600 hover:bg-gold-700 text-black-950 font-semibold py-5 text-lg shadow-xl ring-2 ring-gold-500/30 transition-transform hover:scale-[1.01] focus:outline-none focus:ring-2 focus:ring-gold-500/50"
           >
             <Heart className="w-4 h-4 mr-2" />
             Start Your Fragrance Journey
@@ -128,7 +132,7 @@ export default function QuizIntro() {
           <Button
             variant="outline"
             onClick={() => navigate("/fragrances")}
-            className="w-full border-gold-300 text-gold-300 hover:bg-black-800 hover:text-white"
+            className="w-full border-gold-500/30 text-gold-300 hover:bg-black-900 hover:text-gold-100"
           >
             Browse All Fragrances Instead
           </Button>
@@ -141,11 +145,11 @@ export default function QuizIntro() {
           </p>
           <div className="space-y-2">
             <div className="flex justify-center items-center gap-2 text-xs text-gold-300">
-              <span className="bg-black-800 px-3 py-1.5 rounded-full font-medium">
+              <span className="bg-black-900/60 border border-gold-500/10 px-3 py-1.5 rounded-full font-medium">
                 1. Answer 6 Questions
               </span>
               <span className="text-gold-400">→</span>
-              <span className="bg-black-800 px-3 py-1.5 rounded-full font-medium">
+              <span className="bg-black-900/60 border border-gold-500/10 px-3 py-1.5 rounded-full font-medium">
                 2. AI Analysis
               </span>
             </div>
@@ -153,7 +157,7 @@ export default function QuizIntro() {
               <span className="text-gold-400 text-xs">↓</span>
             </div>
             <div className="flex justify-center">
-              <span className="bg-black-700 px-3 py-1.5 rounded-full font-medium text-xs text-gold-400">
+              <span className="bg-black-900/60 border border-gold-500/10 px-3 py-1.5 rounded-full font-medium text-xs text-gold-400">
                 3. Get Perfect Matches
               </span>
             </div>

--- a/client/pages/QuizIntro.tsx
+++ b/client/pages/QuizIntro.tsx
@@ -126,7 +126,7 @@ export default function QuizIntro() {
 
           <Button
             variant="outline"
-            onClick={() => navigate("/")}
+            onClick={() => navigate("/fragrances")}
             className="w-full border-gold-300 text-gold-300 hover:bg-black-800 hover:text-white"
           >
             Browse All Fragrances Instead


### PR DESCRIPTION
## Purpose

Based on user feedback, this PR addresses requests to:
- Make the quiz page the first/default page users see
- Increase the quiz page's prominence in the navigation
- Enhance the overall visual elegance of the quiz interface

## Code changes

### Routing Updates
- **Default route redirect**: Changed root path `/` to automatically redirect to `/quiz-intro`
- **Fragrances route**: Moved original index page to `/fragrances` path
- **Navigation reordering**: Quiz moved to first position in header navigation

### Visual Enhancements
- **Quiz emphasis**: Added "Start here" badge to Quiz navigation item with gold styling
- **Enhanced styling**: Quiz nav item now has emphasized gold background by default
- **Improved quiz intro page**:
  - Enhanced gradient backgrounds with radial overlay effects
  - Upgraded card styling with gradient borders and rounded corners
  - Improved button styling with shadows, rings, and hover animations
  - Added visual hierarchy with dividers and better spacing
  - Enhanced typography with larger headings and better contrast

### Navigation Improvements
- Quiz navigation item is now visually distinct and emphasized
- Both desktop and mobile navigation updated with consistent styling
- Clear visual indicators guide users to start with the quizTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/d777c026a1e647c4b1c66a29603800e5/curry-verse)

👀 [Preview Link](https://d777c026a1e647c4b1c66a29603800e5-curry-verse.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>d777c026a1e647c4b1c66a29603800e5</projectId>-->
<!--<branchName>curry-verse</branchName>-->